### PR TITLE
Include RequesterAnnotation in rendering of HITs

### DIFF
--- a/mturk-manage.html
+++ b/mturk-manage.html
@@ -309,6 +309,10 @@
       text-decoration: none;
     }
 
+    .hit .annotation {
+      font-style: italic;
+    }
+
     a.faint {
       color: grey;
       text-decoration: none;
@@ -3364,6 +3368,8 @@
                           .addClass(( hit.HITStatus == 'Assignable' ? '' : 'not-avail'))
                     )
                 )
+                .append(
+                  hit.RequesterAnnotation ? $('<div>').addClass('annotation').text( hit.RequesterAnnotation ) : null )
                 .append(
                   $('<div>').addClass('desc').text( hit.Description) )
                 .append(


### PR DESCRIPTION
This little PR includes the RequesterAnnotation in the rendering of HITs. I use this to mark which HIT is which (ie to name them), so it may be generally useful. Let me know what you think!